### PR TITLE
feat: add ACE email templates and skip Jinja2 rendering for specific files

### DIFF
--- a/tutorindigo/templates/indigo/cms/templates/ace_common/edx_ace/common/base_body.html
+++ b/tutorindigo/templates/indigo/cms/templates/ace_common/edx_ace/common/base_body.html
@@ -1,0 +1,217 @@
+{% raw %}
+
+{% load i18n %}
+{% load ace %}
+
+{% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
+
+{# This is preview text that is visible in the inbox view of many email clients but not visible in the actual #}
+{# email itself. #}
+
+<div lang="{{ LANGUAGE_CODE|default:"en" }}" style="
+    display:none;
+    font-size:1px;
+    line-height:1px;
+    max-height:0px;
+    max-width:0px;
+    opacity:0;
+    overflow:hidden;
+    visibility:hidden;
+">
+    {% block preview_text %}{% endblock %}
+</div>
+
+{% for image_src in channel.tracker_image_sources %}
+    <img src="{image_src}" alt="" role="presentation" aria-hidden="true" />
+{% endfor %}
+
+{% google_analytics_tracking_pixel %}
+
+<div lang="{{ LANGUAGE_CODE|default:"en" }}" dir="{{ LANGUAGE_BIDI|yesno:"rtl,ltr" }}" style="
+    background-color: #f5f5f5;
+    margin: 0;
+    min-width: 100%;
+    padding-bottom: 30px;
+    padding-top: 30px;
+">
+    <!-- Hack for outlook 2010, which wants to render everything in Times New Roman -->
+    <!--[if mso]>
+    <style type="text/css">
+    body, table, td {font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;}
+    </style>
+    <![endif]-->
+
+    <!--[if (gte mso 9)|(IE)]>
+    <table role="presentation" width="600" align="center" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+    <td>
+    <![endif]-->
+
+    <!-- CONTENT -->
+    <table class="content" role="presentation" align="center" cellpadding="0" cellspacing="0" border="0" width="100%" style="
+        font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        line-height: 1.5;
+        max-width: 600px;
+        padding: 0 20px 0 20px;
+    ">
+        <tr>
+            <!-- HEADER -->
+            <td class="header" style="
+                padding: 20px 30px;
+            ">
+                <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
+                    <tr>
+                        <td width="70">
+                            <a href="{% with_link_tracking homepage_url %}">
+                                <img
+                                    src="{{ site_configuration_values.BRANDING.logo }}"
+                                    alt="{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}"
+                                    width="{{site_configuration_values.BRANDING.logo_width}}"
+                                    style="max-width: 200px; height: auto;"
+                                    />
+                            </a>
+                        </td>
+                        <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }}; padding-bottom: 6px;">
+                            <a class="login" href="{% with_link_tracking dashboard_url %}" style="color: {{ edly_colors_config.primary }}; text-decoration: none;">
+                                {%  trans "Sign In" %}
+                            </a>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+
+        <tr>
+            <!-- MAIN -->
+            <td class="main" bgcolor="#ffffff" style="
+                padding: 30px 30px 40px;
+                box-shadow: 0 1px 5px rgba(0,0,0,0.25);
+            ">
+                {% block content %}{% endblock %}
+            </td>
+        </tr>
+
+        <tr>
+            <!-- FOOTER -->
+            <td class="footer" style="padding: 20px; text-align: center;">
+                <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
+                    <tr>
+                        <td>
+                            <!-- SOCIAL -->
+                            <table role="presentation" align="{{ LANGUAGE_BIDI|yesno:"right,left" }}" border="0" border="0" cellpadding="0" cellspacing="0" width="210">
+                                <tr>
+                                    {% if social_media_urls.linkedin %}
+                                        <td height="32" width="42">
+                                            <a href="{{ social_media_urls.linkedin|safe }}">
+                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354ec70cb.png"
+                                                     width="32" height="32" alt="{% blocktrans %}{{ platform_name }} on LinkedIn{% endblocktrans %}"/>
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                    {% if social_media_urls.twitter %}
+                                        <td height="32" width="42">
+                                            <a href="{{ social_media_urls.twitter|safe }}">
+                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354d9c26e.png"
+                                                     width="32" height="32" alt="{% blocktrans %}{{ platform_name }} on Twitter{% endblocktrans %}"/>
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                    {% if social_media_urls.facebook %}
+                                        <td height="32" width="42">
+                                            <a href="{{ social_media_urls.facebook|safe }}">
+                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f355052c8e.png"
+                                                     width="32" height="32" alt="{% blocktrans %}{{ platform_name }} on Facebook{% endblocktrans %}"/>
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                    {% if social_media_urls.google_plus %}
+                                        <td height="32" width="42">
+                                            <a href="{{ social_media_urls.google_plus|safe }}">
+                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354fc554a.png"
+                                                     width="32" height="32" alt="{% blocktrans %}{{ platform_name }} on Google Plus{% endblocktrans %}"/>
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                    {% if social_media_urls.reddit %}
+                                        <td height="32" width="42">
+                                            <a href="{{ social_media_urls.reddit|safe }}">
+                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354e326b9.png"
+                                                     width="32" height="32" alt="{% blocktrans %}{{ platform_name }} on Reddit{% endblocktrans %}"/>
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <!-- APP BUTTONS -->
+                        <td>
+                            {% if mobile_store_urls.apple %}
+                                <a href="{{ mobile_store_urls.apple|safe }}" style="text-decoration: none">
+                                    <img src="https://media.sailthru.com/595/1k1/6/2/5931cfbba391b.png"
+                                         alt="{% trans "Download the iOS app on the Apple Store" %}"
+                                         width="136" height="50" style="margin-{{ LANGUAGE_BIDI|yesno:"left,right" }}: 10px"/>
+                                </a>
+                            {% endif %}
+                            {% if mobile_store_urls.google %}
+                                <a href="{{ mobile_store_urls.google|safe }}" style="text-decoration: none">
+                                    <img src="https://media.sailthru.com/595/1k1/6/2/5931cf879a033.png"
+                                         alt="{% trans "Download the Android app on the Google Play Store" %}"
+                                         width="136" height="50"/>
+                                </a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <!-- Actions -->
+                        <td>
+                            {% for action_link_url, action_link_text in channel.action_links %}
+                                <p style="padding-bottom: 20px;">
+                                    <a href="{{ action_link_url }}" style="color: #960909">
+                                        <font color="#960909"><b>{{ action_link_text }}</b></font>
+                                    </a>
+                                </p>
+                            {% endfor %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <!-- COPYRIGHT -->
+                        <td style="color: #666666; font-size: 13px; line-height: 26px;">
+                            {% if site_configuration_values.EDLY_COPYRIGHT_TEXT %}
+                                {{ site_configuration_values.EDLY_COPYRIGHT_TEXT }}
+                            {% else %}
+                                &copy; {{ platform_name }} {% now "Y" %}. {% trans "All rights reserved" %}.
+                            {% endif %}
+                            <br/>
+                            {% trans "Our mailing address is" %}: {{ contact_mailing_address }}
+                        </td>
+                    </tr>
+                    {% if unsubscribe_url %}
+                    <tr>
+                        <td>
+                            If you no longer wish to receive these emails, please <a style="color: #DD1F25;"
+                             href="{{ unsubscribe_url }}">unsubscribe</a> here.
+                        </td>
+                    </tr>
+                    {% endif %}
+                </table>
+            </td>
+        </tr>
+    </table>
+
+    <!--[if (gte mso 9)|(IE)]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+
+</div>
+
+{# Debug info that is not user-visible #}
+<span id="ace-message-id" style="display:none;">{{ message.log_id }}</span>
+<span id="template-revision" style="display:none;">{{ template_revision }}</span>
+
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/ace_common/edx_ace/common/base_head.html
+++ b/tutorindigo/templates/indigo/cms/templates/ace_common/edx_ace/common/base_head.html
@@ -1,0 +1,40 @@
+{% raw %}
+
+{% load i18n %}
+
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+{% get_current_language as LANGUAGE_CODE %}
+<title lang="{{ LANGUAGE_CODE|default:"en" }}">
+  {% block title %}
+  {{ platform_name }}
+  {% endblock %}
+</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+<style type="text/css">
+    @media only screen and (min-device-width: 601px) {
+      .content {
+        width: 600px !important;
+      }
+    }
+
+    @-ms-viewport{
+      width: device-width;
+    }
+
+    /* Column Drop Layout Pattern CSS */
+    @media only screen and (max-width: 450px) {
+      td[class="col"] {
+        display: block;
+        width: 100%;
+        -moz-box-sizing: border-box;
+        -webkit-box-sizing: border-box;
+        box-sizing: border-box;
+        float: left;
+        text-align: left !important;
+        padding-bottom: 20px;
+      }
+    }
+</style>
+
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/ace_common/edx_ace/common/return_to_course_cta.html
+++ b/tutorindigo/templates/indigo/cms/templates/ace_common/edx_ace/common/return_to_course_cta.html
@@ -1,0 +1,37 @@
+{% raw %}
+
+{% load i18n %}
+{% load ace %}
+
+<p style="padding-top: 20px; margin: 0;">
+    {# email client support for style sheets is pretty spotty, so we have to inline all of these styles #}
+    <a
+    {% if course_cta_url %}
+        href="{% with_link_tracking course_cta_url %}"
+    {% else %}
+        {%if course_ids|length > 1 %}
+            href="{% with_link_tracking dashboard_url %}"
+        {% else %}
+            href="{% with_link_tracking course_url %}"
+        {% endif %}
+    {% endif %}
+    style="
+        background: {{ site_configuration_values.COLORS.primary }};
+        border-radius: 3px;
+        -webkit-border-radius: 3px;
+        -moz-border-radius: 3px;
+        color: #fff;
+        display: inline-block;
+        font-size: 15px;
+        font-weight: normal;
+        padding: 10px 20px;
+        text-decoration: none;
+    ">
+        {# old email clients require the use of the font tag :( #}
+        <font color="#ffffff">
+            {{ course_cta_text }}
+        </font>
+    </a>
+</p>
+
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/passwordset/email/body.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/passwordset/email/body.html
@@ -1,0 +1,32 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% trans "Invitation to Join " %} {{ platform_name }}
+            </h1>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}An account has been created for you in {{ platform_name }}. Please use the link below to set your password and log in.{% endblocktrans %}
+                <br />
+            </p>
+
+            {% if failed %}
+                <p style="color: rgba(0,0,0,.75);">
+                    {% trans "If you don't want to join, you can ignore this email." %}
+                    <br />
+                </p>
+            {% else %}
+                {% trans "Set Password" as course_cta_text %}
+
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
+            {% endif %}
+        </td>
+    </tr>
+</table>
+{% endblock %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/passwordset/email/body.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/passwordset/email/body.txt
@@ -1,0 +1,17 @@
+{% raw %}
+
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}An account has been created for you in {{ platform_name }}. Please use the link below to set your password and log in.{% endblocktrans %}
+
+{% if failed %}
+{% trans "If you don't want to join, you can ignore this email." %}
+{% else %}
+{% trans "Please go to the following page and choose a new password:" %}
+
+{{ reset_link }}
+
+{% trans "Thanks for using our site!" %}
+{% endif %}
+{% blocktrans %}The {{ platform_name }} Team{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/passwordset/email/from_name.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/passwordset/email/from_name.txt
@@ -1,0 +1,3 @@
+{% raw %}
+{{ platform_name }}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/passwordset/email/head.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/passwordset/email/head.html
@@ -1,0 +1,3 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_head.html' %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/passwordset/email/subject.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/passwordset/email/subject.txt
@@ -1,0 +1,6 @@
+{% raw %}
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Password set on {{ platform_name }}{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusactivated/email/body.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusactivated/email/body.html
@@ -1,0 +1,23 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% blocktrans %}Hi {{ user }},{% endblocktrans %}
+            </h1>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}Thank you for activating your {{ platform_name }} account. To start exploring, visit: {{ homepage_url }}. Enjoy your learning journey!{% endblocktrans %}
+                <br />
+            </p>
+            {% blocktrans %}The {{ platform_name }} team.{% endblocktrans %}
+            <br />
+        </td>
+    </tr>
+</table>
+{% endblock %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusactivated/email/body.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusactivated/email/body.txt
@@ -1,0 +1,8 @@
+{% raw %}
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Hi {{ user }},{% endblocktrans %}
+{% blocktrans %}Thank you for activating your {{ platform_name }} account. To start exploring, visit: {{ homepage_url }}. Enjoy your learning journey!.{% endblocktrans %}
+
+{% blocktrans %}The {{ platform_name }} team.{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusactivated/email/from_name.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusactivated/email/from_name.txt
@@ -1,0 +1,3 @@
+{% raw %}
+{{ platform_name }}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusactivated/email/head.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusactivated/email/head.html
@@ -1,0 +1,3 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_head.html' %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusactivated/email/subject.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusactivated/email/subject.txt
@@ -1,0 +1,6 @@
+{% raw %}
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Your account has been activated | {{platform_name}}{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusblocked/email/body.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusblocked/email/body.html
@@ -1,0 +1,24 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% blocktrans %}Hi {{ user }},{% endblocktrans %}
+            </h1>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}Your account on {{ platform_name }} has been blocked. If you think this was done in error, please reach out to us at {{ contact_email }}.{% endblocktrans %}
+                <br />
+            </p>
+            {% trans "Best," %}
+            <br />
+            {{ platform_name }}
+        </td>
+    </tr>
+</table>
+{% endblock %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusblocked/email/body.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusblocked/email/body.txt
@@ -1,0 +1,8 @@
+{% raw %}
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Your account on {{ platform_name }} has been blocked. If you think this was done in error, please reach out to us at {{ contact_email }}.{% endblocktrans %}
+
+{% trans "Best," %}
+{% blocktrans %}The {{ platform_name }} Team{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusblocked/email/from_name.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusblocked/email/from_name.txt
@@ -1,0 +1,3 @@
+{% raw %}
+{{ platform_name }}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusblocked/email/head.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusblocked/email/head.html
@@ -1,0 +1,3 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_head.html' %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusblocked/email/subject.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusblocked/email/subject.txt
@@ -1,0 +1,6 @@
+{% raw %}
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Your account has been blocked | {{platform_name}}{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusdeactivated/email/body.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusdeactivated/email/body.html
@@ -1,0 +1,24 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% trans "Hi" %} {{ user }}
+            </h1>
+            <p style="color: rgba(0, 0, 0, 0.75);">
+                {% blocktrans %}Your account on {{ platform_name }} has been deactivated. If you think this was done in error, please reach out to us at {{ contact_email }}.{% endblocktrans %}
+                <br />
+            </p>
+            {% trans "Best," %}
+            <br />
+            {{ platform_name }}
+        </td>
+    </tr>
+</table>
+{% endblock %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusdeactivated/email/body.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusdeactivated/email/body.txt
@@ -1,0 +1,8 @@
+{% raw %}
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Your account on {{ platform_name }} has been deactivated. If you think this was done in error, please reach out to us at {{ contact_email }}.{% endblocktrans %}
+
+{% trans "Thanks for using our site!" %}
+{% blocktrans %}The {{ platform_name }} Team{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusdeactivated/email/from_name.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusdeactivated/email/from_name.txt
@@ -1,0 +1,3 @@
+{% raw %}
+{{ platform_name }}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusdeactivated/email/head.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusdeactivated/email/head.html
@@ -1,0 +1,3 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_head.html' %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusdeactivated/email/subject.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusdeactivated/email/subject.txt
@@ -1,0 +1,6 @@
+{% raw %}
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Your account has been deactivated | {{platform_name}}{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusunblocked/email/body.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusunblocked/email/body.html
@@ -1,0 +1,24 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% blocktrans %}Hi {{ user }},{% endblocktrans %}
+            </h1>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}Your account has been unblocked. Please reset your password to continue your learning. To reset password, visit: {{ password_reset_url }}{% endblocktrans %}
+                <br />
+            </p>
+            {% trans "Best," %}
+            <br />
+            {{ platform_name }}
+        </td>
+    </tr>
+</table>
+{% endblock %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusunblocked/email/body.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusunblocked/email/body.txt
@@ -1,0 +1,8 @@
+{% raw %}
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Your account has been unblocked. Please reset your password to continue your learning. To reset password, visit: {{ password_reset_url }}{% endblocktrans %}
+
+{% trans "Best," %}
+{% blocktrans %}The {{ platform_name }} Team{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusunblocked/email/from_name.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusunblocked/email/from_name.txt
@@ -1,0 +1,3 @@
+{% raw %}
+{{ platform_name }}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusunblocked/email/head.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusunblocked/email/head.html
@@ -1,0 +1,3 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_head.html' %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusunblocked/email/subject.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/userstatusunblocked/email/subject.txt
@@ -1,0 +1,6 @@
+{% raw %}
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Your account has been unblocked | {{platform_name}}{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/ace_common/edx_ace/common/base_body.html
+++ b/tutorindigo/templates/indigo/lms/templates/ace_common/edx_ace/common/base_body.html
@@ -1,0 +1,217 @@
+{% raw %}
+
+{% load i18n %}
+{% load ace %}
+
+{% get_current_language as LANGUAGE_CODE %}
+{% get_current_language_bidi as LANGUAGE_BIDI %}
+
+{# This is preview text that is visible in the inbox view of many email clients but not visible in the actual #}
+{# email itself. #}
+
+<div lang="{{ LANGUAGE_CODE|default:"en" }}" style="
+    display:none;
+    font-size:1px;
+    line-height:1px;
+    max-height:0px;
+    max-width:0px;
+    opacity:0;
+    overflow:hidden;
+    visibility:hidden;
+">
+    {% block preview_text %}{% endblock %}
+</div>
+
+{% for image_src in channel.tracker_image_sources %}
+    <img src="{image_src}" alt="" role="presentation" aria-hidden="true" />
+{% endfor %}
+
+{% google_analytics_tracking_pixel %}
+
+<div lang="{{ LANGUAGE_CODE|default:"en" }}" dir="{{ LANGUAGE_BIDI|yesno:"rtl,ltr" }}" style="
+    background-color: #f5f5f5;
+    margin: 0;
+    min-width: 100%;
+    padding-bottom: 30px;
+    padding-top: 30px;
+">
+    <!-- Hack for outlook 2010, which wants to render everything in Times New Roman -->
+    <!--[if mso]>
+    <style type="text/css">
+    body, table, td {font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif !important;}
+    </style>
+    <![endif]-->
+
+    <!--[if (gte mso 9)|(IE)]>
+    <table role="presentation" width="600" align="center" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+    <td>
+    <![endif]-->
+
+    <!-- CONTENT -->
+    <table class="content" role="presentation" align="center" cellpadding="0" cellspacing="0" border="0" width="100%" style="
+        font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        line-height: 1.5;
+        max-width: 600px;
+        padding: 0 20px 0 20px;
+    ">
+        <tr>
+            <!-- HEADER -->
+            <td class="header" style="
+                padding: 20px 30px;
+            ">
+                <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
+                    <tr>
+                        <td width="70">
+                            <a href="{% with_link_tracking homepage_url %}">
+                                <img
+                                    src="{{ site_configuration_values.BRANDING.logo }}"
+                                    alt="{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}"
+                                    width="{{site_configuration_values.BRANDING.logo_width}}"
+                                    style="max-width: 200px; height: auto;"
+                                    />
+                            </a>
+                        </td>
+                        <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }}; padding-bottom: 6px;">
+                            <a class="login" href="{% with_link_tracking dashboard_url %}" style="color: {{ edly_colors_config.primary }}; text-decoration: none;">
+                                {%  trans "Sign In" %}
+                            </a>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+
+        <tr>
+            <!-- MAIN -->
+            <td class="main" bgcolor="#ffffff" style="
+                padding: 30px 30px 40px;
+                box-shadow: 0 1px 5px rgba(0,0,0,0.25);
+            ">
+                {% block content %}{% endblock %}
+            </td>
+        </tr>
+
+        <tr>
+            <!-- FOOTER -->
+            <td class="footer" style="padding: 20px; text-align: center;">
+                <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
+                    <tr>
+                        <td>
+                            <!-- SOCIAL -->
+                            <table role="presentation" align="{{ LANGUAGE_BIDI|yesno:"right,left" }}" border="0" border="0" cellpadding="0" cellspacing="0" width="210">
+                                <tr>
+                                    {% if social_media_urls.linkedin %}
+                                        <td height="32" width="42">
+                                            <a href="{{ social_media_urls.linkedin|safe }}">
+                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354ec70cb.png"
+                                                     width="32" height="32" alt="{% blocktrans %}{{ platform_name }} on LinkedIn{% endblocktrans %}"/>
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                    {% if social_media_urls.twitter %}
+                                        <td height="32" width="42">
+                                            <a href="{{ social_media_urls.twitter|safe }}">
+                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354d9c26e.png"
+                                                     width="32" height="32" alt="{% blocktrans %}{{ platform_name }} on Twitter{% endblocktrans %}"/>
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                    {% if social_media_urls.facebook %}
+                                        <td height="32" width="42">
+                                            <a href="{{ social_media_urls.facebook|safe }}">
+                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f355052c8e.png"
+                                                     width="32" height="32" alt="{% blocktrans %}{{ platform_name }} on Facebook{% endblocktrans %}"/>
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                    {% if social_media_urls.google_plus %}
+                                        <td height="32" width="42">
+                                            <a href="{{ social_media_urls.google_plus|safe }}">
+                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354fc554a.png"
+                                                     width="32" height="32" alt="{% blocktrans %}{{ platform_name }} on Google Plus{% endblocktrans %}"/>
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                    {% if social_media_urls.reddit %}
+                                        <td height="32" width="42">
+                                            <a href="{{ social_media_urls.reddit|safe }}">
+                                                <img src="https://media.sailthru.com/595/1k1/8/o/599f354e326b9.png"
+                                                     width="32" height="32" alt="{% blocktrans %}{{ platform_name }} on Reddit{% endblocktrans %}"/>
+                                            </a>
+                                        </td>
+                                    {% endif %}
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <!-- APP BUTTONS -->
+                        <td>
+                            {% if mobile_store_urls.apple %}
+                                <a href="{{ mobile_store_urls.apple|safe }}" style="text-decoration: none">
+                                    <img src="https://media.sailthru.com/595/1k1/6/2/5931cfbba391b.png"
+                                         alt="{% trans "Download the iOS app on the Apple Store" %}"
+                                         width="136" height="50" style="margin-{{ LANGUAGE_BIDI|yesno:"left,right" }}: 10px"/>
+                                </a>
+                            {% endif %}
+                            {% if mobile_store_urls.google %}
+                                <a href="{{ mobile_store_urls.google|safe }}" style="text-decoration: none">
+                                    <img src="https://media.sailthru.com/595/1k1/6/2/5931cf879a033.png"
+                                         alt="{% trans "Download the Android app on the Google Play Store" %}"
+                                         width="136" height="50"/>
+                                </a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <!-- Actions -->
+                        <td>
+                            {% for action_link_url, action_link_text in channel.action_links %}
+                                <p style="padding-bottom: 20px;">
+                                    <a href="{{ action_link_url }}" style="color: #960909">
+                                        <font color="#960909"><b>{{ action_link_text }}</b></font>
+                                    </a>
+                                </p>
+                            {% endfor %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <!-- COPYRIGHT -->
+                        <td style="color: #666666; font-size: 13px; line-height: 26px;">
+                            {% if site_configuration_values.EDLY_COPYRIGHT_TEXT %}
+                                {{ site_configuration_values.EDLY_COPYRIGHT_TEXT }}
+                            {% else %}
+                                &copy; {{ platform_name }} {% now "Y" %}. {% trans "All rights reserved" %}.
+                            {% endif %}
+                            <br/>
+                            {% trans "Our mailing address is" %}: {{ contact_mailing_address }}
+                        </td>
+                    </tr>
+                    {% if unsubscribe_url %}
+                    <tr>
+                        <td>
+                            If you no longer wish to receive these emails, please <a style="color: #DD1F25;"
+                             href="{{ unsubscribe_url }}">unsubscribe</a> here.
+                        </td>
+                    </tr>
+                    {% endif %}
+                </table>
+            </td>
+        </tr>
+    </table>
+
+    <!--[if (gte mso 9)|(IE)]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+
+</div>
+
+{# Debug info that is not user-visible #}
+<span id="ace-message-id" style="display:none;">{{ message.log_id }}</span>
+<span id="template-revision" style="display:none;">{{ template_revision }}</span>
+
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/ace_common/edx_ace/common/base_head.html
+++ b/tutorindigo/templates/indigo/lms/templates/ace_common/edx_ace/common/base_head.html
@@ -1,0 +1,40 @@
+{% raw %}
+
+{% load i18n %}
+
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+{% get_current_language as LANGUAGE_CODE %}
+<title lang="{{ LANGUAGE_CODE|default:"en" }}">
+  {% block title %}
+  {{ platform_name }}
+  {% endblock %}
+</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+<style type="text/css">
+    @media only screen and (min-device-width: 601px) {
+      .content {
+        width: 600px !important;
+      }
+    }
+
+    @-ms-viewport{
+      width: device-width;
+    }
+
+    /* Column Drop Layout Pattern CSS */
+    @media only screen and (max-width: 450px) {
+      td[class="col"] {
+        display: block;
+        width: 100%;
+        -moz-box-sizing: border-box;
+        -webkit-box-sizing: border-box;
+        box-sizing: border-box;
+        float: left;
+        text-align: left !important;
+        padding-bottom: 20px;
+      }
+    }
+</style>
+
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/ace_common/edx_ace/common/return_to_course_cta.html
+++ b/tutorindigo/templates/indigo/lms/templates/ace_common/edx_ace/common/return_to_course_cta.html
@@ -1,0 +1,37 @@
+{% raw %}
+
+{% load i18n %}
+{% load ace %}
+
+<p style="padding-top: 20px; margin: 0;">
+    {# email client support for style sheets is pretty spotty, so we have to inline all of these styles #}
+    <a
+    {% if course_cta_url %}
+        href="{% with_link_tracking course_cta_url %}"
+    {% else %}
+        {%if course_ids|length > 1 %}
+            href="{% with_link_tracking dashboard_url %}"
+        {% else %}
+            href="{% with_link_tracking course_url %}"
+        {% endif %}
+    {% endif %}
+    style="
+        background: {{ site_configuration_values.COLORS.primary }};
+        border-radius: 3px;
+        -webkit-border-radius: 3px;
+        -moz-border-radius: 3px;
+        color: #fff;
+        display: inline-block;
+        font-size: 15px;
+        font-weight: normal;
+        padding: 10px 20px;
+        text-decoration: none;
+    ">
+        {# old email clients require the use of the font tag :( #}
+        <font color="#ffffff">
+            {{ course_cta_text }}
+        </font>
+    </a>
+</p>
+
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/user_authn/edx_ace/passwordreset/email/body.html
+++ b/tutorindigo/templates/indigo/lms/templates/user_authn/edx_ace/passwordreset/email/body.html
@@ -1,0 +1,43 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h2 style="margin: 0; padding-top: 10px; padding-bottom: 10px;">
+                {% trans "Password Reset" %}
+            </h2>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}You are receiving this e-mail because you requested a password reset for your user account at {{ platform_name }}.{% endblocktrans %}
+                <br />
+            </p>
+
+            {% if failed %}
+                <p style="color: rgba(0,0,0,.75);">
+                    {% blocktrans %}However, there is currently no user account associated with your email address: {{ email_address }}.{% endblocktrans %}
+                    <br />
+                </p>
+
+                <p style="color: rgba(0,0,0,.75);">
+                    {% trans "If you did not request this change, you can ignore this email." %}
+                    <br />
+                </p>
+            {% else %}
+                <p style="color: rgba(0,0,0,.75);">
+                    {% trans "If you did not request this change, you can disregard this email - we have not yet reset your password." %}
+                    <br />
+                </p>
+
+                {% trans "Change my Password" as course_cta_text %}
+
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
+            {% endif %}
+        </td>
+    </tr>
+</table>
+{% endblock %}
+
+{% endraw %}


### PR DESCRIPTION
This commit introduces new email templates for the ACE system, including base head, body, and call-to-action components. Additionally, it updates the templates with `raw` tag to escape the jinja syntax