### PR TITLE
feat: add welcome email templates for cross-tenant and second site users

### DIFF
--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/secondsitewelcome/email/body.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/secondsitewelcome/email/body.html
@@ -1,0 +1,33 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <p style="font-size: 28px; line-height: 36px; margin: 0 0 16px; font-weight: 700; color: #2d2d2d;">
+                {% blocktrans %}You have been invited to {{ platform_name }}.{% endblocktrans %}
+            </p>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}To begin your learning journey, simply sign in using the login details you set up for {{ source_site }}.{% endblocktrans %}
+            </p>
+            <p style="color: rgba(0,0,0,.75);">
+                {% trans "In case you've forgotten your password, you may click reset password. You may also request your organization admin to send you a reset password link." %}
+            </p>
+            {% if login_url %}
+                {% trans "Sign in" as course_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=login_url %}
+            {% endif %}
+            {% if reset_password_url %}
+            <p style="margin: 12px 0 0;">
+                <a href="{{ reset_password_url }}" style="color: {{ site_configuration_values.COLORS.primary }}; text-decoration: underline; font-size: 16px;">
+                    {% trans "Forgot Password?" %}
+                </a>
+            </p>
+            {% endif %}
+        </td>
+    </tr>
+</table>
+{% endblock %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/secondsitewelcome/email/body.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/secondsitewelcome/email/body.txt
@@ -1,0 +1,12 @@
+{% raw %}
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}You have been invited to {{ platform_name }}.{% endblocktrans %}
+
+{% blocktrans %}To begin your learning journey, simply sign in using the login details you set up for {{ source_site }}.{% endblocktrans %}
+
+{% trans "In case you've forgotten your password, you may click reset password. You may also request your organization admin to send you a reset password link." %}
+
+{% if login_url %}{{ login_url }}{% endif %}
+{% if reset_password_url %}{% trans "Forgot Password" %}: {{ reset_password_url }}{% endif %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/secondsitewelcome/email/from_name.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/secondsitewelcome/email/from_name.txt
@@ -1,0 +1,3 @@
+{% raw %}
+{{ platform_name }}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/secondsitewelcome/email/head.html
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/secondsitewelcome/email/head.html
@@ -1,0 +1,3 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_head.html' %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/secondsitewelcome/email/subject.txt
+++ b/tutorindigo/templates/indigo/cms/templates/edly_panel_app/edx_ace/secondsitewelcome/email/subject.txt
@@ -1,0 +1,6 @@
+{% raw %}
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}You have been invited to {{ platform_name }}{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/crosstenantwelcome/email/body.html
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/crosstenantwelcome/email/body.html
@@ -1,0 +1,26 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <p style="font-size: 28px; line-height: 36px; margin: 0 0 16px; font-weight: 700; color: #2d2d2d;">
+                {% blocktrans %}Welcome to {{ platform_name }}{% endblocktrans %}
+            </p>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}Start your learning journey with {{ platform_name }}.{% endblocktrans %}
+            </p>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}Please note that your account is linked to your account on {{ source_site }}.{% endblocktrans %}
+            </p>
+            {% if login_url %}
+                {% trans "Sign in" as course_cta_text %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=login_url %}
+            {% endif %}
+        </td>
+    </tr>
+</table>
+{% endblock %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/crosstenantwelcome/email/body.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/crosstenantwelcome/email/body.txt
@@ -1,0 +1,11 @@
+{% raw %}
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Welcome to {{ platform_name }}{% endblocktrans %}
+
+{% blocktrans %}Start your learning journey with {{ platform_name }}.{% endblocktrans %}
+
+{% blocktrans %}Please note that your account is linked to your account on {{ source_site }}.{% endblocktrans %}
+
+{% trans "Sign in" %}: {{ login_url }}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/crosstenantwelcome/email/from_name.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/crosstenantwelcome/email/from_name.txt
@@ -1,0 +1,3 @@
+{% raw %}
+{{ platform_name }}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/crosstenantwelcome/email/head.html
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/crosstenantwelcome/email/head.html
@@ -1,0 +1,3 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_head.html' %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/crosstenantwelcome/email/subject.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/crosstenantwelcome/email/subject.txt
@@ -1,0 +1,6 @@
+{% raw %}
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Welcome to {{ platform_name }}{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}


### PR DESCRIPTION
## Description
This commit introduces new email templates for welcoming users to the platform, including HTML and plain text formats for both cross-tenant and second site scenarios. The templates include personalized messages and sign-in links, enhancing user onboarding experience.

## Ticket
https://projects.arbisoft.com/project/edly-product/task/8194