### PR TITLE
feat: add email templates for course certificate generation

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/certificategeneration/email/body.html
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/certificategeneration/email/body.html
@@ -1,0 +1,51 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load django_markup %}
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% trans "Course Certificate Generated" as header_msg %}{{ header_msg | force_escape }}
+            </h1>
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                    {% blocktrans %}Hi {{ platform_name }} team,{% endblocktrans %}
+                {% endfilter %}
+            </p>
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                    {% blocktrans %}Congratulations, {{ student_name }} has completed the course - "{{ course_name }}" on {{ course_date }} with certificate {{ cert_url }}.{% endblocktrans %}
+                {% endfilter %}  
+            </p>
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                    {% blocktrans %}{{ student_name }} has earned a certificate. Lets, encourage {{ student_name }} to share this achievement with others by writing a personalised email to {{ student_email }}.{% endblocktrans %}
+                {% endfilter %}
+            </p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                    {% blocktrans %}{{ platform_name }}{% endblocktrans %}
+                {% endfilter %}
+                <br />
+            </p>
+        </td>
+    </tr>
+        <td>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans trimmed asvar assist_msg %}
+                If you need help, please use our email {start_anchor_email}{formatted_support_email}{end_anchor}.
+                {% endblocktrans %}
+                <br />
+            </p>
+        </td>
+</table>
+{% endblock %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/certificategeneration/email/body.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/certificategeneration/email/body.txt
@@ -1,0 +1,12 @@
+{% raw %}
+{% load i18n %}{% autoescape off %}
+{% blocktrans %} {{ platform_name }} {% endblocktrans %}
+
+
+{% blocktrans %}Hi {{ platform_name }} team,{% endblocktrans %}
+
+{% blocktrans %}Congratulations, {{ student_name }} has completed the course - {{ course_name }} on {{ course_date }}.{% endblocktrans %}
+
+{% blocktrans %}{{ student_name }} has earned a certificate. Lets, encourage {{ student_name }} to share this achievement with others by writing a personalised email {{ student_email }}.{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/certificategeneration/email/from_name.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/certificategeneration/email/from_name.txt
@@ -1,0 +1,3 @@
+{% raw %}
+{{ platform_name }}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/certificategeneration/email/head.html
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/certificategeneration/email/head.html
@@ -1,0 +1,3 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_head.html' %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/certificategeneration/email/subject.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/certificategeneration/email/subject.txt
@@ -1,0 +1,6 @@
+{% raw %}
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %} Learner has earned a new certificate {{ platform_name }}{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}


### PR DESCRIPTION
This commit introduces new email templates for notifying users about course certificate generation. It includes HTML and plain text formats, featuring personalized messages for students and their respective platforms, enhancing communication regarding course completions.


## Ticket
https://projects.arbisoft.com/project/edly-product/task/8311