### PR TITLE
fix: prevent duplicate logo in MFE header

### DIFF
--- a/tutorindigo/patches/mfe-env-config-runtime-final
+++ b/tutorindigo/patches/mfe-env-config-runtime-final
@@ -1,4 +1,8 @@
 
+if (config.pluginSlots && config.pluginSlots['logo_slot']) {
+  config.pluginSlots['logo_slot'].keepDefault = false;
+}
+
 if (config.pluginSlots && config.pluginSlots['org.openedx.frontend.layout.footer.v1']) {
   const footerPluginsToInsert =
     config.pluginSlots['org.openedx.frontend.layout.footer.v1'].plugins.filter(plugin => plugin.op === 'insert');


### PR DESCRIPTION
## Summary
- The FBR logo was appearing twice side by side in the Learner Dashboard MFE header
- `_add_themed_logo` inserts `ThemedLogo` into `logo_slot` for all MFEs, but `addPlugins()` hardcodes `keepDefault: true`, causing the default brand logo to render alongside `ThemedLogo`
- Fix: set `keepDefault: false` for `logo_slot` in `mfe-env-config-runtime-final`, so only `ThemedLogo` renders — same pattern as the existing footer deduplication fix in that file

## Test plan
- [ ] Trigger dev-deploy workflow to rebuild MFE images
- [ ] Verify only one FBR logo appears in the Learner Dashboard MFE header
- [ ] Verify dark mode still correctly shows the white logo variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)