### PR TITLE
fix: deduplicate custom_logo insert in logo_slot at runtime

### DIFF
--- a/tutorindigo/patches/mfe-env-config-runtime-final
+++ b/tutorindigo/patches/mfe-env-config-runtime-final
@@ -1,6 +1,21 @@
 
 if (config.pluginSlots && config.pluginSlots['logo_slot']) {
   config.pluginSlots['logo_slot'].keepDefault = false;
+
+  const logoInsertPlugins =
+    config.pluginSlots['logo_slot'].plugins.filter(plugin => plugin.op === 'insert' && plugin.widget?.id === 'custom_logo');
+
+  if (logoInsertPlugins.length > 1) {
+    let kept = false;
+    config.pluginSlots['logo_slot'].plugins =
+      config.pluginSlots['logo_slot'].plugins.filter(plugin => {
+        if (plugin.op === 'insert' && plugin.widget?.id === 'custom_logo') {
+          if (kept) return false;
+          kept = true;
+        }
+        return true;
+      });
+  }
 }
 
 if (config.pluginSlots && config.pluginSlots['org.openedx.frontend.layout.footer.v1']) {


### PR DESCRIPTION
## Summary
- Fixes duplicate logo rendering in MFE headers by deduplicating `custom_logo` insert plugins in `logo_slot` at runtime
- The `_add_themed_logo` hook adds a `custom_logo` insert for every MFE, which can result in duplicate entries in `env.config.jsx`
- Adds a runtime check in `mfe-env-config-runtime-final` that keeps only the first `custom_logo` insert, mirroring the existing footer slot dedup logic

## Test plan
- [x] Deploy to staging using `deploy` or `quick-deploy` comment
- [x] Verify only one logo appears in MFE headers (learning, learner-dashboard, profile, account, discussions, authoring, authn)
- [x] Inspect `env.config.jsx` in the MFE container to confirm `logo_slot` has a single `custom_logo` insert

🤖 Generated with [Claude Code](https://claude.com/claude-code)