### PR TITLE
feat: add SASS files for honor certificates in LTR and RTL

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/certificates/sass/main-ltr.scss
+++ b/tutorindigo/templates/indigo/lms/static/certificates/sass/main-ltr.scss
@@ -1,0 +1,12 @@
+@import '../../../../../../edx-platform/lms/static/sass/vendor/bi-app/bi-app-ltr';
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/mixins';
+
+@import '../../../../../../edx-platform/lms/static/certificates/sass/build';
+
+// EDLY CUSTOM: Show logo/signature on honor certificates (core hides via display:none)
+.layout-accomplishment.certificate-honor .accomplishment-rendering .accomplishment-signatories .signatory-signature,
+.layout-accomplishment.certificate-honor .accomplishment-rendering .accomplishment-type-symbol {
+    display: block !important;
+}

--- a/tutorindigo/templates/indigo/lms/static/certificates/sass/main-rtl.scss
+++ b/tutorindigo/templates/indigo/lms/static/certificates/sass/main-rtl.scss
@@ -1,0 +1,12 @@
+@import '../../../../../../edx-platform/lms/static/sass/vendor/bi-app/bi-app-rtl';
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/mixins';
+
+@import '../../../../../../edx-platform/lms/static/certificates/sass/build';
+
+// EDLY CUSTOM: Show logo/signature on honor certificates (core hides via display:none)
+.layout-accomplishment.certificate-honor .accomplishment-rendering .accomplishment-signatories .signatory-signature,
+.layout-accomplishment.certificate-honor .accomplishment-rendering .accomplishment-type-symbol {
+    display: block !important;
+}


### PR DESCRIPTION
## Description
Introduced main-ltr.scss and main-rtl.scss to manage styles for honor certificates. These files override core CSS to ensure signatory signatures and logos are displayed correctly. This enhancement improves the visual presentation of honor certificates.

## Ticket
https://projects.arbisoft.com/arbisoft/browse/EDLYPRODUCT-5453/