### PR TITLE
feat: Redirect Program Enroll Button to Discover Page

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/learner_dashboard/program_details_fragment.html
+++ b/tutorindigo/templates/indigo/lms/templates/learner_dashboard/program_details_fragment.html
@@ -1,0 +1,66 @@
+## mako
+
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+from openedx.core.djangolib.js_utils import (
+    dump_js_escaped_json, js_escaped_string
+)
+%>
+
+<div class="js-program-details-wrapper program-details-wrapper"></div>
+
+<%block name="js_extra">
+<%static:webpack entry="ProgramDetailsFactory">
+ProgramDetailsFactory({
+    programData: ${program_data | n, dump_js_escaped_json},
+    courseData: ${course_data | n, dump_js_escaped_json},
+    certificateData: ${certificate_data | n, dump_js_escaped_json},
+    urls: ${urls | n, dump_js_escaped_json},
+    userPreferences: ${user_preferences | n, dump_js_escaped_json},
+    industryPathways: ${industry_pathways | n, dump_js_escaped_json},
+    creditPathways: ${credit_pathways | n, dump_js_escaped_json},
+    programTabViewEnabled: ${program_tab_view_enabled | n, dump_js_escaped_json},
+    discussionFragment: ${discussion_fragment, | n, dump_js_escaped_json},
+    live_fragment: ${live_fragment, | n, dump_js_escaped_json}
+});
+</%static:webpack>
+
+<script>
+    // Intercept enroll button clicks and redirect to discover page.
+    (function() {
+        const courseData = ${course_data | n, dump_js_escaped_json};
+        const urlsByUuid = {};
+
+        // courseData groups courses by enrollment status
+        ['in_progress', 'not_started', 'completed'].forEach(function(category) {
+            (courseData[category] || []).forEach(function(course) {
+                const runs = course.course_runs || [];
+                for (let i = 0; i < runs.length; i++) {
+                    if (runs[i].marketing_url) {
+                        urlsByUuid[course.uuid] = runs[i].marketing_url;
+                        break;
+                    }
+                }
+            });
+        });
+
+        document.querySelector('.js-program-details-wrapper')
+            .addEventListener('click', function(e) {
+                const btn = e.target.closest('.enroll-button button, .enroll-button .enroll-course-button');
+                if (!btn) return;
+
+                const section = btn.closest('[id^="course-"]');
+                if (!section) return;
+
+                const uuid = section.id.replace('course-', '');
+                const url = urlsByUuid[uuid];
+                if (url) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    window.location.href = url;
+                }
+            }, true);
+    })();
+</script>
+</%block>

--- a/tutorindigo/templates/indigo/lms/templates/learner_dashboard/program_details_fragment.html
+++ b/tutorindigo/templates/indigo/lms/templates/learner_dashboard/program_details_fragment.html
@@ -6,6 +6,17 @@
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
+
+def build_marketing_urls(course_data):
+    """Build a {course_uuid: marketing_url} lookup from course_data."""
+    urls = {}
+    for category in ('in_progress', 'not_started', 'completed'):
+        for course in course_data.get(category, []):
+            for run in course.get('course_runs', []):
+                if run.get('marketing_url'):
+                    urls[course['uuid']] = run['marketing_url']
+                    break
+    return urls
 %>
 
 <div class="js-program-details-wrapper program-details-wrapper"></div>
@@ -29,21 +40,7 @@ ProgramDetailsFactory({
 <script>
     // Intercept enroll button clicks and redirect to discover page.
     (function() {
-        const courseData = ${course_data | n, dump_js_escaped_json};
-        const urlsByUuid = {};
-
-        // courseData groups courses by enrollment status
-        ['in_progress', 'not_started', 'completed'].forEach(function(category) {
-            (courseData[category] || []).forEach(function(course) {
-                const runs = course.course_runs || [];
-                for (let i = 0; i < runs.length; i++) {
-                    if (runs[i].marketing_url) {
-                        urlsByUuid[course.uuid] = runs[i].marketing_url;
-                        break;
-                    }
-                }
-            });
-        });
+        const urlsByUuid = ${build_marketing_urls(course_data) | n, dump_js_escaped_json};
 
         document.querySelector('.js-program-details-wrapper')
             .addEventListener('click', function(e) {


### PR DESCRIPTION
## Description

[Edly-41](https://projects.arbisoft.com/arbisoft/browse/EDLYPRODUCT-41/)

- Override `program_details_fragment.html` to inject a capture-phase click listener that intercepts "Enroll Now" button clicks on the program detail page
- Redirects users to the course's discover/marketing page instead of triggering the default LMS enrollment flow
- Uses course UUID from the DOM to look up the `marketing_url` from server-side course data

## Why this approach
- The enroll button is rendered by `course_enroll.underscore`, which is bundled by webpack at build time from edx-platform paths — webpack doesn't resolve from the themes directory, so `.underscore` overrides via themes don't work
- Mako templates (`.html`) are resolved at runtime by Django's `ThemeTemplateLoader`, making theme overrides work correctly
- This avoids any edx-platform changes

