### PR TITLE
feat: wire DiscussionSidebarWidget into learning footer slot

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -152,7 +152,7 @@ for mfe in indigo_styled_mfes:
             (
                 f"mfe-env-config-runtime-definitions-{mfe}",
                 """
-                const { HeaderWidget, FooterWidget, MultiSiteBannerWidget } = require("@anas_hameed/edly-saas-widget");
+                const { HeaderWidget, FooterWidget, MultiSiteBannerWidget, DiscussionSidebarWidget } = require("@anas_hameed/edly-saas-widget");
                 """,
             )
         ]
@@ -249,6 +249,17 @@ ACCOUNT_FOOTER_WIDGET = FOOTER_WIDGET + """
 },
 """
 
+LEARNING_FOOTER_WIDGET = FOOTER_WIDGET + """
+{
+    op: PLUGIN_OPERATIONS.Insert,
+    widget: {
+        id: 'discussion_sidebar_closed_by_default',
+        type: DIRECT_PLUGIN,
+        RenderWidget: DiscussionSidebarWidget,
+    },
+},
+"""
+
 HEADER_WIDGET = """
 {
     op: PLUGIN_OPERATIONS.Hide,
@@ -282,7 +293,7 @@ CERTIFICATE_WIDGET =  """
 
 MFE_CONFIG = {
     "learning": {
-        "footer_slot": FOOTER_WIDGET,
+        "footer_slot": LEARNING_FOOTER_WIDGET,
         "header_slot": HEADER_WIDGET,
         "progress_certificate_status_slot": CERTIFICATE_WIDGET
     },


### PR DESCRIPTION
## Summary

Wires the new `DiscussionSidebarWidget` from `@anas_hameed/edly-saas-widget` into the learning MFE so the in-context discussions (forums) sidebar is hidden by default on course pages. The widget swaps the discussions sidebar for the course outline whenever the iframe appears.

Pairs with: edly-io/frontend-saas-widgets#7 (widget definition).

## Changes (`tutorindigo/plugin.py`)

- Import `DiscussionSidebarWidget` alongside the existing widgets in `mfe-env-config-runtime-definitions-<mfe>`.
- New `LEARNING_FOOTER_WIDGET` constant — `FOOTER_WIDGET` + an `Insert` op that renders `DiscussionSidebarWidget` (id `discussion_sidebar_closed_by_default`).
- `MFE_CONFIG["learning"]["footer_slot"]` now points at `LEARNING_FOOTER_WIDGET` instead of plain `FOOTER_WIDGET`. Other MFEs (`account`, etc.) are unaffected.

## Why footer_slot?

The widget is headless (renders `null`) and just needs to be mounted somewhere on the learning MFE. `footer_slot` already supports plugin injection and is present on every learning page, including course pages where the widget actually does its work.

## Test plan

- [ ] `tutor images build openedx` (or `mfe`) succeeds with the updated env config.
- [ ] Bump `@anas_hameed/edly-saas-widget` to a version that exports `DiscussionSidebarWidget` (≥ 0.2.6) in the consuming MFE.
- [ ] On a course page in the learning MFE, discussions sidebar is replaced by the course outline.
- [ ] Other MFEs (account, etc.) still render their existing footer widgets unchanged.