### PR TITLE
Install edl-features app into the openedx image

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -107,6 +107,15 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
 hooks.Filters.CONFIG_OVERRIDES.add_items(list(config["overrides"].items()))
 
 
+# Install the edl-features app into the openedx image
+hooks.Filters.ENV_PATCHES.add_item(
+    (
+        "openedx-dockerfile-post-python-requirements",
+        "RUN pip install 'edl-features @ git+https://github.com/edly-io/edl-features.git@master'",
+    )
+)
+
+
 #  MFEs that are styled using Indigo
 indigo_styled_mfes = [
     "learning",


### PR DESCRIPTION
Add a openedx-dockerfile-post-python-requirements patch that pip-installs the edl-features Open edX plugin app from the private edly-io/edl-features repo, so it is registered with LMS/CMS when the image is built.