### PR TITLE
feat: align legacy LMS header navigation with MFEs

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/header/navbar-authenticated.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/navbar-authenticated.html
@@ -14,6 +14,10 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
   show_explore_courses = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
   self.real_user = getattr(user, 'real_user', user)
   enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
+  show_courses_link = user.is_authenticated
+  show_programs_link = user.is_authenticated and getattr(settings, 'ENABLE_PROGRAMS', False)
+  sessions_url = getattr(settings, 'SESSIONS_MICROFRONTEND_URL', '')
+  admin_url = (getattr(settings, 'FBR_ADMIN_BASE_URL', '') or getattr(settings, 'FBR_ADMIN_MICROFRONTEND_URL', '')) if getattr(self.real_user, 'is_staff', False) else ''
 
   support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
   doc_link = get_online_help_info(online_help_token)['doc_url']
@@ -28,27 +32,43 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
 <div class="nav-links">
   <div class="main">
-    % if show_dashboard_tabs:
+    % if show_courses_link:
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
         <a class="${'active ' if reverse('dashboard') == request.path else ''}tab-nav-link" href="${reverse('dashboard')}"
              aria-current="${'page' if reverse('dashboard') == request.path else 'false'}">
-             ${_("My Courses")}
+             ${_("Courses")}
         </a>
       </div>
-      % if show_program_listing:
+    % endif
+    % if show_programs_link:
         <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
           <a class="${'active ' if reverse('program_listing_view') in request.path else ''}tab-nav-link" href="${reverse('program_listing_view')}"
              aria-current="${'page' if reverse('program_listing_view') == request.path else 'false'}">
              ${_("Programs")}
           </a>
         </div>
-      % endif
     % endif
     % if show_explore_courses:
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
           <a class="${'active ' if reverse('courses') == request.path else ''}tab-nav-link discover-new-link" href="${marketing_link('COURSES')}"
              aria-current="${'page' if '/courses' in request.path else 'false'}">
-             ${_('Discover')}
+             ${_('Discover New')}
+          </a>
+      </div>
+    % endif
+    % if sessions_url:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if '/sessions' in request.path else ''}tab-nav-link" href="${sessions_url}"
+             aria-current="${'page' if '/sessions' in request.path else 'false'}">
+             ${_("Calendar")}
+          </a>
+      </div>
+    % endif
+    % if admin_url:
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
+          <a class="${'active ' if '/fbr-admin' in request.path else ''}tab-nav-link" href="${admin_url}"
+             aria-current="${'page' if '/fbr-admin' in request.path else 'false'}">
+             ${_("Admin Console")}
           </a>
       </div>
     % endif


### PR DESCRIPTION
## Summary

Updates the Indigo legacy LMS header to align its navigation with the FBR MFE headers.

## Changes

- Added and aligned Courses, Programs, Discover New, Calendar, and Administration navigation items.
- Added page-aware active navigation styling.
- Kept navigation consistent across legacy Django-rendered LMS pages and MFEs.

## Reason

Legacy LMS pages use the Indigo server-rendered header rather than the React MFE header, so their navigation must be configured separately.

## Testing

- Verified navigation links on legacy LMS pages.
- Verified the correct active item is underlined.

## Screenshots:
<img width="1918" height="920" alt="611818280-49ceffd4-0770-4f63-b537-b7f5327cfe33" src="https://github.com/user-attachments/assets/2c9758b9-66fb-42a3-9a39-035c93f2a011" />
<img width="1919" height="921" alt="611818012-c3e670fc-174c-4588-af99-0455abb7c3c4" src="https://github.com/user-attachments/assets/d33f28df-581d-45fa-a921-66e79a91860a" />
