### PR TITLE
fix: match font size of mfe & fjango template footer and localize org name

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/sass/extra/_footer.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/extra/_footer.scss
@@ -9,6 +9,7 @@ footer.tutor-container {
     max-width: none;
     box-sizing: border-box;
     color: #fff;
+    font-size: 16px;
 
     a {
       color: #fff;


### PR DESCRIPTION
related commit: https://github.com/edly-io/openedx-translations/commit/86cdb8641c94ce6ce5127688b67add92204b6c56