### PR TITLE
Create mfe-caddyfile

### DIFF
--- a/tutorindigo/patches/mfe-caddyfile
+++ b/tutorindigo/patches/mfe-caddyfile
@@ -1,0 +1,1 @@
+redir / {% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ LMS_HOST }}


### PR DESCRIPTION
fix: learner-dashboard courses click redirects to blank page issue on prod