### PR TITLE
fix: certificate error

### DIFF
--- a/tutorindigo/patches/openedx-lms-common-settings
+++ b/tutorindigo/patches/openedx-lms-common-settings
@@ -12,3 +12,4 @@ FEATURES['ENABLE_MKTG_SITE'] = True
 ENABLE_MKTG_SITE = True
 MKTG_URLS['ROOT'] = '{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://site.{{ LMS_HOST }}'
 MKTG_URLS['COURSES'] = '{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://site.{{ LMS_HOST }}/courses/'
+MKTG_URLS['ABOUT'] = '{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://site.{{ LMS_HOST }}/about/'


### PR DESCRIPTION
Error Trace
```
lms-1         | 2026-06-29 07:18:16,702 INFO 15 [lms.djangoapps.certificates.views.webview] [user 5] [ip 110.39.173.34] webview.py:549 - certificate language is: en for the course: course-v1:Rwaq+T2+2026
lms-1         | 2026-06-29 07:18:16,726 ERROR 15 [common.djangoapps.util.views] [user 5] [ip 110.39.173.34] views.py:148 - Error in django view.
lms-1         | Traceback (most recent call last):
lms-1         |   File "/openedx/edx-platform/common/djangoapps/util/views.py", line 139, in inner
lms-1         |     return func(request, *args, **kwargs)
lms-1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1         |   File "/openedx/venv/lib/python3.11/site-packages/edx_django_utils/plugins/pluggable_override.py", line 77, in wrapper
lms-1         |     return prev_fn(*args, **kwargs)
lms-1         |            ^^^^^^^^^^^^^^^^^^^^^^^^
lms-1         |   File "/openedx/edx-platform/lms/djangoapps/certificates/views/webview.py", line 614, in render_html_view
lms-1         |     response = _render_valid_certificate(request, context, custom_template)
lms-1         |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1         |   File "/openedx/edx-platform/lms/djangoapps/certificates/views/webview.py", line 704, in _render_valid_certificate
lms-1         |     return render_to_response("certificates/valid.html", context)
lms-1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1         |   File "/openedx/edx-platform/common/djangoapps/edxmako/shortcuts.py", line 188, in render_to_response
lms-1         |     return HttpResponse(render_to_string(template_name, dictionary, namespace, request), **kwargs)
lms-1         |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1         |   File "/openedx/edx-platform/common/djangoapps/edxmako/shortcuts.py", line 178, in render_to_string
lms-1         |     return template.render(dictionary, request)
lms-1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1         |   File "/openedx/edx-platform/common/djangoapps/edxmako/template.py", line 82, in render
lms-1         |     return self.mako_template.render_unicode(**context_dictionary)
lms-1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1         |   File "/openedx/venv/lib/python3.11/site-packages/mako/template.py", line 439, in render_unicode
lms-1         |     return runtime._render(
lms-1         |            ^^^^^^^^^^^^^^^^
lms-1         |   File "/openedx/venv/lib/python3.11/site-packages/mako/runtime.py", line 874, in _render
lms-1         |     _render_context(
lms-1         |   File "/openedx/venv/lib/python3.11/site-packages/mako/runtime.py", line 916, in _render_context
lms-1         |     _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
lms-1         |   File "/openedx/venv/lib/python3.11/site-packages/mako/runtime.py", line 943, in _exec_template
lms-1         |     callable_(context, *args, **kwargs)
lms-1         |   File "/tmp/mako_lms/f7954c31fd60fa4ed1f565c51047d523/certificates/accomplishment-base.html.py", line 108, in render_body
lms-1         |     __M_writer(filters.html_escape(filters.decode.utf8(self.body())))
lms-1         |                                                        ^^^^^^^^^^^
lms-1         |   File "/tmp/mako_lms/f7954c31fd60fa4ed1f565c51047d523/certificates/valid.html.py", line 50, in render_body
lms-1         |     runtime._include_file(context, '_about-edx.html', _template_uri)
lms-1         |   File "/openedx/venv/lib/python3.11/site-packages/mako/runtime.py", line 793, in _include_file
lms-1         |     callable_(ctx, **kwargs)
lms-1         |   File "/tmp/mako_lms/f7954c31fd60fa4ed1f565c51047d523/certificates/_about-edx.html.py", line 33, in render_body
lms-1         |     __M_writer(filters.html_escape(filters.decode.utf8(company_about_url)))
lms-1         |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lms-1         |   File "/openedx/venv/lib/python3.11/site-packages/mako/filters.py", line 47, in decode
lms-1         |     return decode(str(x))
lms-1         |                   ^^^^^^
lms-1         |   File "/openedx/venv/lib/python3.11/site-packages/mako/runtime.py", line 230, in __str__
lms-1         |     raise NameError("Undefined")
lms-1         | NameError: Undefined
lms-1         | 2026-06-29 07:18:16,783 INFO 15 [edx.footer] [user 5] [ip 110.39.173.34] api.py:479 - images/logo.png
```