### PR TITLE
fix: add missing otpmessage email template override

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.html
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.html
@@ -1,0 +1,37 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
+                {% blocktrans %}Your verification code for {{ platform_name }}{% endblocktrans %}
+                {% endautoescape %}
+            </h1>
+
+            <p style="font-size: 28px; font-weight: bold; letter-spacing: 4px; color: rgba(0,0,0,.85);">
+                {{ otp_code }}
+            </p>
+
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                {% blocktrans %}This code will expire in a few minutes. If you did not attempt to log in, you can safely ignore this email.{% endblocktrans %}
+                {% endfilter %}
+                <br />
+            </p>
+
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                {% blocktrans %}This email was automatically sent from {{ platform_name }}.{% endblocktrans %}
+                {% endfilter %}
+                <br />
+            </p>
+        </td>
+    </tr>
+</table>
+{% endblock %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.html
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.html
@@ -17,7 +17,7 @@
                 <tr>
                     <td style="font-size: 18px; line-height: 24px; padding: 0 20px 20px; color: #6F6D6D;">
                         {% blocktrans %}Hello {{ user_name }},{% endblocktrans %}<br />
-                        Your one time verification code is:
+                        {% trans "Your one time verification code is:" %}
                     </td>
                 </tr>
                 <tr>

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.html
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.html
@@ -2,34 +2,46 @@
 {% extends 'ace_common/edx_ace/common/base_body.html' %}
 
 {% load i18n %}
+{% load static %}
+
 {% block content %}
-<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" style="font-family: 'Roboto', sans-serif;">
     <tr>
-        <td>
-            <h1>
-                {% autoescape off %}
-                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
-                {% blocktrans %}Your verification code for {{ platform_name }}{% endblocktrans %}
-                {% endautoescape %}
-            </h1>
-
-            <p style="font-size: 28px; font-weight: bold; letter-spacing: 4px; color: rgba(0,0,0,.85);">
-                {{ otp_code }}
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This code will expire in a few minutes. If you did not attempt to log in, you can safely ignore this email.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
-
-            <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
-                {% blocktrans %}This email was automatically sent from {{ platform_name }}.{% endblocktrans %}
-                {% endfilter %}
-                <br />
-            </p>
+        <td align="center" style="padding-bottom: 100px">
+            <table border="0" cellpadding="0" cellspacing="0" style="width: 670px; background-color: #fff; font-size: 16px; color: #6f6d6d; margin: 0 auto;">
+                <tr>
+                    <td style="font-size: 20px; padding: 20px 20px 30px; font-weight: 500; color: #4A4D52;">
+                        {% trans "Login Verification Code" %} - {{ platform_name }}
+                    </td>
+                </tr>
+                <tr>
+                    <td style="font-size: 18px; line-height: 24px; padding: 0 20px 20px; color: #6F6D6D;">
+                        {% blocktrans %}Hello {{ user_name }},{% endblocktrans %}<br />
+                        Your one time verification code is:
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 10px 20px 30px; text-align: center;">
+                        <table style="width: 100%; border: 0;" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td style="color: #4A4D52; padding: 0px 0px 10px; border-top: 1px solid #B7B8BA; font-size: 32px;">
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="color: #DD1F25; font-weight: 600; padding: 0 20px 20px; font-size: 40px;">
+                                    {{ otp_code }}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="font-size: 18px; line-height: 24px; color: #6F6D6D; padding-top: 50px; border-top: 1px solid #B7B8BA;">
+                                    {% blocktrans %}This code will expire in {{ expiry_minutes }} minutes.{% endblocktrans %}<br />
+                                    {% trans "Once the code expires, you will have to resubmit a request for a new code." %}
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
         </td>
     </tr>
 </table>

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.txt
@@ -2,7 +2,7 @@
 {% load i18n %}{% autoescape off %}
 {% blocktrans %}Hello {{ user_name }},{% endblocktrans %}
 
-{% blocktrans %}Your verification code is: {{ otp_code }}{% endblocktrans %}
+{% trans "Your one time verification code is:" %} {{ otp_code }}
 
 {% blocktrans %}This code will expire in {{ expiry_minutes }} minutes.{% endblocktrans %}
 

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.txt
@@ -1,10 +1,14 @@
 {% raw %}
-{% load i18n %}{% autoescape off %}{% blocktrans %}Your verification code for {{ platform_name }} is:{% endblocktrans %}
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Hello {{ user_name }},{% endblocktrans %}
 
-{{ otp_code }}
+{% blocktrans %}Your verification code is: {{ otp_code }}{% endblocktrans %}
 
-{% blocktrans %}This code will expire in a few minutes. If you did not attempt to log in, you can safely ignore this email.{% endblocktrans %}
+{% blocktrans %}This code will expire in {{ expiry_minutes }} minutes.{% endblocktrans %}
 
-----
-{% blocktrans %}This email was automatically sent from {{ platform_name }}.{% endblocktrans %}{% endautoescape %}
+{% trans "Once the code expires, you will have to resubmit a request for a new code." %}
+
+{% trans "Best regards," %}
+{% blocktrans %}{{ platform_name }} Team{% endblocktrans %}
+{% endautoescape %}
 {% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/body.txt
@@ -1,0 +1,10 @@
+{% raw %}
+{% load i18n %}{% autoescape off %}{% blocktrans %}Your verification code for {{ platform_name }} is:{% endblocktrans %}
+
+{{ otp_code }}
+
+{% blocktrans %}This code will expire in a few minutes. If you did not attempt to log in, you can safely ignore this email.{% endblocktrans %}
+
+----
+{% blocktrans %}This email was automatically sent from {{ platform_name }}.{% endblocktrans %}{% endautoescape %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/from_name.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/from_name.txt
@@ -1,0 +1,3 @@
+{% raw %}
+{{ platform_name }}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/head.html
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/head.html
@@ -1,0 +1,3 @@
+{% raw %}
+{% extends 'ace_common/edx_ace/common/base_head.html' %}
+{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/subject.txt
+++ b/tutorindigo/templates/indigo/lms/templates/edly_features_app/edx_ace/otpmessage/email/subject.txt
@@ -1,0 +1,6 @@
+{% raw %}
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Login Verification Code - {{ platform_name }}{% endblocktrans %}
+{% endautoescape %}
+{% endraw %}


### PR DESCRIPTION
## Summary
## What
Adds Indigo theme override templates for the `OTPMessage` ACE email type, giving OTP (one-time password) emails the same branded styling as other `edly_features_app` emails (`certificategeneration`, `crosstenantwelcome`).

## Why
Without a theme override, Django's template loader falls back to the in-plugin template — the email is delivered but unbranded. A companion PR ([link to companion PR]) removes that in-plugin template to clean up the plugin. This PR adds the theme-level override so there is always exactly one template in the right place.

## ⚠️ Co-deploy dependency
This PR **must be deployed together with or before** the companion PR that removes the in-plugin template. If the companion lands first with no theme override in place, ACE will find no template and OTP emails will fail silently (the `send_otp_email` caller catches the exception).

## What this PR does NOT do
This is a branding/consistency change, not a fix for any reported OTP email delivery failure. If OTP emails are not being delivered on a site, the root cause is elsewhere (SiteConfiguration, sender domain, Celery, feature flags, etc.) and needs a separate investigation.

