### PR TITLE
fix: gradebook info-icon renders as tofu due to FA6/FA4 cascade conflict

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -260,6 +260,35 @@ LEARNING_FOOTER_WIDGET = FOOTER_WIDGET + """
 },
 """
 
+# EDLYCUSTOM: frontend-saas-widgets' FooterWidget injects a FontAwesome 6 CDN
+# stylesheet (all.min.css) globally. FooterWidget/HeaderWidget render outside
+# <main> (see gradebook's App.jsx), but gradebook's own legacy Paragon icons
+# (GradebookFilters, LabelReplacements, SpinnerIcon) render raw `fa fa-*`
+# classNames inside <main> and depend on gradebook's self-hosted FontAwesome 4.
+# A separate, unscoped `.fa{font-family:"Font Awesome 6 Free"!important}` rule
+# (no matching @font-face) wins the cascade and breaks those icons (tofu glyph).
+# Scoping this restore to `main` only fixes gradebook's own icons without
+# touching FooterWidget/HeaderWidget's FontAwesome 6 usage elsewhere.
+GRADEBOOK_FOOTER_WIDGET = FOOTER_WIDGET + """
+{
+    op: PLUGIN_OPERATIONS.Insert,
+    widget: {
+        id: 'edly_gradebook_fa4_icon_fix',
+        type: DIRECT_PLUGIN,
+        RenderWidget: () => (
+            <style>
+                {`
+                    main .fa {
+                        font-family: "FontAwesome" !important;
+                        font-weight: normal !important;
+                    }
+                `}
+            </style>
+        ),
+    },
+},
+"""
+
 HEADER_WIDGET = """
 {
     op: PLUGIN_OPERATIONS.Hide,
@@ -302,6 +331,10 @@ MFE_CONFIG = {
     },
     "account": {
         "footer_slot": ACCOUNT_FOOTER_WIDGET,
+        "desktop_header_slot": HEADER_WIDGET,
+    },
+    "gradebook": {
+        "footer_slot": GRADEBOOK_FOOTER_WIDGET,
         "desktop_header_slot": HEADER_WIDGET,
     },
 }

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -260,15 +260,8 @@ LEARNING_FOOTER_WIDGET = FOOTER_WIDGET + """
 },
 """
 
-# EDLYCUSTOM: frontend-saas-widgets' FooterWidget injects a FontAwesome 6 CDN
-# stylesheet (all.min.css) globally. FooterWidget/HeaderWidget render outside
-# <main> (see gradebook's App.jsx), but gradebook's own legacy Paragon icons
-# (GradebookFilters, LabelReplacements, SpinnerIcon) render raw `fa fa-*`
-# classNames inside <main> and depend on gradebook's self-hosted FontAwesome 4.
-# A separate, unscoped `.fa{font-family:"Font Awesome 6 Free"!important}` rule
-# (no matching @font-face) wins the cascade and breaks those icons (tofu glyph).
-# Scoping this restore to `main` only fixes gradebook's own icons without
-# touching FooterWidget/HeaderWidget's FontAwesome 6 usage elsewhere.
+# EDLYCUSTOM: FooterWidget's FA6 CDN import breaks gradebook's own FA4 icons.
+# Scoped to `main` so it doesn't touch Header/FooterSlot's own FA6 usage.
 GRADEBOOK_FOOTER_WIDGET = FOOTER_WIDGET + """
 {
     op: PLUGIN_OPERATIONS.Insert,


### PR DESCRIPTION
## Summary
- Gradebook's Total Grade (%) info-circle icon (and its filter/spinner icons) render as a tofu/square glyph because `frontend-saas-widgets`' `FooterWidget` injects a FontAwesome 6 CDN stylesheet (`all.min.css`, via `indigo_styled_mfes`), which introduces a global, unscoped `.fa{font-family:"Font Awesome 6 Free"!important}` rule with no matching local `@font-face`. That `!important` rule wins the cascade over gradebook's own working, self-hosted FontAwesome 4 icons.
- Gradebook is the only Indigo-styled MFE affected — all other MFEs (learning, account, authn, authoring, learner-dashboard) render icons via `FontAwesomeIcon` (inline SVG), which never touches the `.fa` webfont class at all.
- Fix: insert a small `<style>` widget into gradebook's `footer_slot`, scoped to `main`, restoring `.fa` to FontAwesome 4 for gradebook's own icons only. Per gradebook's own `App.jsx`, `<main>` contains only `GradebookPage` — `Header`/`FooterSlot` (where the FA6 CDN and any per-tenant footer icon content render) are separate siblings, so this doesn't touch their FontAwesome 6 usage.

## Test plan
- [ ] `tutor dev start` with this plugin change, load a gradebook page, confirm Total Grade (%) info icon, filter icon, and loading spinner all render correctly (not tofu).
- [ ] Confirm site footer / header icons (rendered via `FooterWidget`/`HeaderWidget`, FontAwesome 6) are unaffected on gradebook and elsewhere.
- [ ] Confirm no regression on other `indigo_styled_mfes` (learning, account, authoring, etc.) — unaffected, this change only touches gradebook's `MFE_CONFIG` entry.