### PR TITLE
feat: add RWAQ_VIDEO_PLAYBACK_BASE_URL for passthrough video status

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -123,6 +123,13 @@ hooks.Filters.CONFIG_DEFAULTS.add_item(("RWAQ_VIDEO_S3_BUCKET", ""))
 hooks.Filters.CONFIG_DEFAULTS.add_item(
     ("RWAQ_VIDEO_S3_HOST", "s3.eu-central-1.amazonaws.com")
 )
+# Base URL that uploaded videos are played back from (CloudFront distribution or
+# the bucket's public/website endpoint). Consumed by the rwaq-features passthrough
+# video-status signal to build the edx-val encoded_video URL. Inert until set.
+hooks.Filters.CONFIG_DEFAULTS.add_item(("RWAQ_VIDEO_PLAYBACK_BASE_URL", ""))
+# Region of the video bucket, used by the passthrough signal's boto3 HeadObject
+# (to read the uploaded file size). Kept in sync with RWAQ_VIDEO_S3_HOST above.
+hooks.Filters.CONFIG_DEFAULTS.add_item(("RWAQ_VIDEO_S3_REGION", "eu-central-1"))
 
 hooks.Filters.ENV_PATCHES.add_items(
     [
@@ -144,6 +151,10 @@ VIDEO_UPLOAD_PIPELINE:
   ROOT_PATH: "video"
   CONCURRENT_UPLOAD_LIMIT: 4
   HOST: "{{ RWAQ_VIDEO_S3_HOST }}"
+  REGION: "{{ RWAQ_VIDEO_S3_REGION }}"
+# Consumed by rwaq-features' passthrough video-status signal (marks Studio
+# uploads "Ready" without transcoding).
+RWAQ_VIDEO_PLAYBACK_BASE_URL: "{{ RWAQ_VIDEO_PLAYBACK_BASE_URL }}"
 {% endif %}
 """,
         ),


### PR DESCRIPTION
## What

Adds the settings the [rwaq-features passthrough video-status handler](https://github.com/edly-io/rwaq-features/pull/79) needs, alongside the existing `VIDEO_UPLOAD_PIPELINE` block. Addresses the review question on rwaq-features#79 ([discussion](https://github.com/edly-io/rwaq-features/pull/79#discussion_r3628976675)).

- **`RWAQ_VIDEO_PLAYBACK_BASE_URL`** (default `""`) — base URL uploaded videos are played back from (CloudFront distribution or the bucket endpoint). The handler builds the edx-val `encoded_video` URL as `{RWAQ_VIDEO_PLAYBACK_BASE_URL}/{ROOT_PATH}/{edx_video_id}` when it marks a Studio upload **Ready**. Exposed as a top-level CMS Django setting.
- **`RWAQ_VIDEO_S3_REGION`** (default `eu-central-1`) — fed into `VIDEO_UPLOAD_PIPELINE` as `REGION` so the handler's `boto3` `HeadObject` (used only to read the uploaded file size) signs correctly for the regional bucket. Kept in sync with `RWAQ_VIDEO_S3_HOST`.

Both sit under the existing `{% if RWAQ_VIDEO_S3_BUCKET %}` guard, so they're **inert until the bucket is configured** — consistent with the rest of the video-upload gating.

## Diff

```python
hooks.Filters.CONFIG_DEFAULTS.add_item(("RWAQ_VIDEO_PLAYBACK_BASE_URL", ""))
hooks.Filters.CONFIG_DEFAULTS.add_item(("RWAQ_VIDEO_S3_REGION", "eu-central-1"))
```
```yaml
# cms-env, inside {% if RWAQ_VIDEO_S3_BUCKET %}
VIDEO_UPLOAD_PIPELINE:
  ...
  REGION: "{{ RWAQ_VIDEO_S3_REGION }}"
RWAQ_VIDEO_PLAYBACK_BASE_URL: "{{ RWAQ_VIDEO_PLAYBACK_BASE_URL }}"
```

## To activate on an environment

Set in the tutor config (then rebuild/restart CMS):
```yaml
RWAQ_VIDEO_S3_BUCKET: "<bucket>"
RWAQ_VIDEO_PLAYBACK_BASE_URL: "https://<cloudfront-or-bucket-endpoint>"
```

Base is `ulmo/rwaq` (where the rest of the RWAQ video config lives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)